### PR TITLE
Update junit version from 4.11.x to 4.13.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 <dependency>
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
-    <version>4.11</version>
+    <version>4.13.1</version>
 </dependency>
 
 <dependency>


### PR DESCRIPTION
The Junit 4.11 version contains security vulnerability. For more information check out [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250).